### PR TITLE
Build with -Zminimal-versions in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ rust:
   - beta
   - nightly
 
-matrix:
-  allow_failures:
-    - rust: nightly
-
 env:
   global:
   # Improves coverage accuracy
@@ -44,6 +40,9 @@ before_script:
 script:
   - cargo build --all --verbose
   - cargo test --all --verbose
+  - | if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
+        cargo update -Zminimal-versions
+        cargo build --all
 
 after_success:
 - |

--- a/blosc/Cargo.toml
+++ b/blosc/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["compression"]
 
 [dependencies]
 blosc-sys = "1.14.4"
-libc = "0.1"
+libc = "0.2.4"
 
 # For official releases, comment out the dependency patch
 # [patch.crates-io]


### PR DESCRIPTION
Also,
* Don't allow build failures on nightly.  Nobody would ever check.
* Require at least libc 0.2.4