### PR TITLE
Run cargo fmt and cargo clippy

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,7 @@ test_task:
   matrix:
     - name: MSRV
       container:
-        image: rust:1.32.0
+        image: rust:1.34.0
     - name: stable
       container:
         image: rust:latest

--- a/blosc-sys/Cargo.toml
+++ b/blosc-sys/Cargo.toml
@@ -11,3 +11,4 @@ Rust FFI bindings to the C-BLOSC compression library
 documentation = "https://docs.rs/blosc-sys"
 categories = ["external-ffi-bindings"]
 keywords = ["compression"]
+links = "blosc"

--- a/blosc-sys/src/lib.rs
+++ b/blosc-sys/src/lib.rs
@@ -1,4 +1,5 @@
 // vim: tw=80
+#![allow(clippy::redundant_static_lifetimes)]
 //! Rust FFI bindings for the C-Blosc block-oriented compression library
 //!
 //! These are raw, `unsafe` FFI bindings.  Here be dragons!  You probably

--- a/blosc/Cargo.toml
+++ b/blosc/Cargo.toml
@@ -13,12 +13,8 @@ categories = ["api-bindings"]
 keywords = ["compression"]
 
 [dependencies]
-blosc-sys = "1.14.4"
+blosc-sys = { version = "1.14.5-pre", path = "../blosc-sys" }
 libc = "0.2.4"
-
-# For official releases, comment out the dependency patch
-# [patch.crates-io]
-# blosc-sys = { path = "../blosc-sys" }
 
 [dev-dependencies]
 bincode = "1.0"

--- a/blosc/tests/test.rs
+++ b/blosc/tests/test.rs
@@ -1,7 +1,8 @@
 // vim: tw=80
 
 extern crate blosc;
-#[macro_use] extern crate galvanic_test;
+#[macro_use]
+extern crate galvanic_test;
 extern crate rand;
 
 use blosc::*;


### PR DESCRIPTION
Part of the split of #6.

This PR is the result of `cargo fmt` and `cargo clippy`. The first commit is only there to ensure we always build against exactly one `blosc-sys` (links attribute), and that `blosc` pulls in the correct version of `blosc-sys`. This syntax is still valid when publishing, and does the right thing.