### PR TITLE
Remove some obsolete arguments to rustfmt

### DIFF
--- a/blosc-sys/bindgen.sh
+++ b/blosc-sys/bindgen.sh
@@ -5,4 +5,4 @@ bindgen --no-rustfmt-bindings \
 	--whitelist-type '.*BLOSC.*' \
 	--whitelist-function '.*blosc.*' \
 	--whitelist-var '.*BLOSC.*' /usr/local/include/blosc.h > src/bindgen.rs
-rustfmt --force --write-mode replace src/bindgen.rs
+rustfmt src/bindgen.rs


### PR DESCRIPTION
I can't figure out which version of rustfmt deleted them.