### PR TITLE
Derive (Partial)Eq/Ord on appropriate enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased] - ReleaseDate
+
 ### Added
 
 - Added `validate`, which requires c-blosc 1.16.0 or later
   ([#23](https://github.com/nix-rust/nix/pull/23))
+- Implemented `(Partial)Eq` on `Clevel`, `ShuffleMode`, `Context`; `(Partial)Ord` on `Clevel` ([#25](https://github.com/asomers/blosc-rs/pull/25))
 
 ### Changed
 

--- a/blosc/src/lib.rs
+++ b/blosc/src/lib.rs
@@ -24,8 +24,7 @@
 use blosc_sys::*;
 use std::{
     convert::Into,
-    error,
-    fmt,
+    error, fmt,
     hash::{Hash, Hasher},
     marker::PhantomData,
     os::raw::{c_char, c_int, c_void},
@@ -47,7 +46,7 @@ impl error::Error for BloscError {}
 pub type Result<T> = std::result::Result<T, BloscError>;
 
 /// The desired compression level.  Higher levels mean more compression.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord)]
 #[repr(i32)]
 pub enum Clevel {
     /// No compression at all.
@@ -114,7 +113,7 @@ impl From<Compressor> for *const c_char {
 /// The Shuffle operation is the key to efficiently compressing arrays.  It
 /// rearranges the array to put every entry's MSB together and every entry's LSB
 /// together, which improves the performance of every `Compressor`.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(i32)]
 pub enum ShuffleMode {
     /// No shuffle.  Use this mode for data that is not an array.
@@ -138,7 +137,7 @@ pub enum ShuffleMode {
 
 /// Holds basic settings for `compress` operations.
 // LCOV_EXCL_START
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Context {
     blocksize: usize,
     clevel: Clevel,
@@ -433,11 +432,13 @@ pub unsafe fn decompress_bytes<T>(src: &[u8]) -> Result<Vec<T>> {
 /// ```
 pub fn validate(src: &[u8]) -> Result<usize> {
     let mut len: usize = 0;
-    let r = unsafe { blosc_cbuffer_validate(
-        src.as_ptr() as *const c_void,
-        src.len(),
-        &mut len as *mut usize
-    )};
+    let r = unsafe {
+        blosc_cbuffer_validate(
+            src.as_ptr() as *const c_void,
+            src.len(),
+            &mut len as *mut usize,
+        )
+    };
     if r == 0 {
         Ok(len)
     } else {


### PR DESCRIPTION
- `Clevel` gets (Partial)Eq, (Partial)Ord
- `ShuffleMode` gets (Partial)Eq
- `Context` gets (Partial)Eq

These are useful for testing, at a minimum, but could be useful when comparing configs in other settings.