### PR TITLE
Explicitly install clippy during CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -75,6 +75,7 @@ task:
     image: rustlang/rust:nightly
   << : *LINUX_SETUP
   extra_setup_script:
+    - rustup component add clippy
     - cargo install cargo-audit
   cargo_cache:
     folder: $CARGO_HOME/registry


### PR DESCRIPTION
It used to be included in the rust:latest image, but no longer is.