### PR TITLE
Switch CI from using -Zminimal-versions to -Zdirect-minimal-versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,7 +50,7 @@ task:
   cargo_cache:
     folder: $CARGO_HOME/registry
   build_script:
-    - cargo update -Zminimal-versions
+    - cargo update -Zdirect-minimal-versions
     - cargo check --all --all-targets
   before_cache_script: rm -rf $CARGO_HOME/registry/index
     

--- a/blosc/Cargo.toml
+++ b/blosc/Cargo.toml
@@ -19,11 +19,11 @@ exclude = [
 
 [dependencies]
 blosc-sys = { version = "1.21.0", path = "../blosc-sys" }
-libc = "0.2.4"
+libc = "0.2.29"
 thiserror = "1.0"
 
 [dev-dependencies]
 bincode = "1.0"
 rand = "0.7.0"
 rstest = "0.17.0"
-serde = "1.0"
+serde = "1.0.27"


### PR DESCRIPTION
The latter is preferable since updates to our dependencies can't suddenly break our build.  But it does require us to specify our own dependencies a little more tightly.