### PR TITLE
During CI, run "cargo audit" before clippy

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -80,6 +80,6 @@ task:
   cargo_cache:
     folder: $CARGO_HOME/registry
   build_script:
-    - cargo clippy --all-targets
     - cargo audit
+    - cargo clippy --all-targets
   before_cache_script: rm -rf $CARGO_HOME/registry/index


### PR DESCRIPTION
Because clippy will write a new Cargo.lock file, and the latest cargo-audit doesn't understand v4 lock files.