### PR TITLE
Deprecate the crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,24 @@ compression library for binary data, especially numeric arrays.  The
 `blosc-sys` crate provides raw FFI bindings for C-Blosc.  You probably don't
 want to use it directly.
 
+> [!WARNING]
+> This crate is deprecated.  The author no longer uses it in his own projects,
+> and new alternatives have arisen.  If you use this crate, then I suggest you
+> either:
+>
+> * Volunteer to take over maintainership from me.
+> * Switch to the [byteshuffle](https://crates.io/crates/byteshuffle) crate, if
+>   all you care about is the shuffle filter.
+> * Switch to the [blosc-rs](https://crates.io/crates/blosc-rs/) crate.
+> * Switch to the [blosc2](https://crates.io/crates/blosc2) crate.
+> * Switch to the [blosc2-rs](https://crates.io/crates/blosc2-rs) crate.
+
 # Usage
 
 ```toml
 # Cargo.toml
 [dependencies]
-blosc = "0.2"
+blosc = "0.3"
 ```
 
 ```rust

--- a/blosc/Cargo.toml
+++ b/blosc/Cargo.toml
@@ -17,6 +17,9 @@ exclude = [
   "tests/**/*.rs"
 ]
 
+[badges]
+maintenance = { status = "deprecated" }
+
 [dependencies]
 blosc-sys = { version = "1.21.0", path = "../blosc-sys" }
 libc = "0.2.29"

--- a/blosc/README.md
+++ b/blosc/README.md
@@ -7,12 +7,24 @@ Rust bindings for the C-Blosc compression library.
 The `blosc` crate provides Rusty bindings for [`C-Blosc`](http://blosc.org/), a
 compression library for binary data, especially numeric arrays.
 
+> [!WARNING]
+> This crate is deprecated.  The author no longer uses it in his own projects,
+> and new alternatives have arisen.  If you use this crate, then I suggest you
+> either:
+>
+> * Volunteer to take over maintainership from me.
+> * Switch to the [byteshuffle](https://crates.io/crates/byteshuffle) crate, if
+>   all you care about is the shuffle filter.
+> * Switch to the [blosc-rs](https://crates.io/crates/blosc-rs/) crate.
+> * Switch to the [blosc2](https://crates.io/crates/blosc2) crate.
+> * Switch to the [blosc2-rs](https://crates.io/crates/blosc2-rs) crate.
+
 # Usage
 
 ```toml
 # Cargo.toml
 [dependencies]
-blosc = "0.1"
+blosc = "0.3"
 ```
 
 ```rust


### PR DESCRIPTION
The author no longer uses it in his own projects, and new alternatives have arisen.  If you use this crate, then I suggest you either assume maintainership, of switch to an alternative.